### PR TITLE
来料导入，手持端”物料查询“优化

### DIFF
--- a/src/api/gc/material-lot-manager/MaterialLotManagerRequest.js
+++ b/src/api/gc/material-lot-manager/MaterialLotManagerRequest.js
@@ -95,4 +95,16 @@ export default class MaterialLotManagerRequest {
         MessageUtils.sendRequest(requestObject);
     }
 
+    static sendGetDataByLotIdOrMLotAndTableRrnRequest = (object) => {
+        let {queryLotId, tableRrn} = object;
+        let requestBody = MaterialLotManagerRequestBody.buildGetDataByLotIdOrMLotAndTableRrn(queryLotId, tableRrn);
+        let requestHeader = new MaterialLotManagerRequestHeader();
+        let request = new Request(requestHeader,requestBody,UrlConstant.GCMaterialLotManagerUrl);
+        let requestObject = {
+            request: request,
+            success: object.success
+        }
+        MessageUtils.sendRequest(requestObject);
+    }
+
 }

--- a/src/api/gc/material-lot-manager/MaterialLotManagerRequestBody.js
+++ b/src/api/gc/material-lot-manager/MaterialLotManagerRequestBody.js
@@ -7,6 +7,7 @@ const ActionType = {
     QueryMLot: "QueryMLot",
     CancelCheck: "CancelCheck",
     QueryMaterialLotIdOrLotId: "QueryMaterialLotIdOrLotId",
+    QueryData: "QueryData",
 }
 
 
@@ -73,6 +74,13 @@ export default class MaterialLotManagerRequestBody {
         let materialLotManagerRequestBody = new MaterialLotManagerRequestBody(ActionType.QueryMLot, undefined, undefined, queryLotId);
         materialLotManagerRequestBody.setTabRrn(tableRrn);
         return materialLotManagerRequestBody;    
+    }
+
+    static buildGetDataByLotIdOrMLotAndTableRrn(queryLotId, tableRrn) {
+        let body =  new MaterialLotManagerRequestBody(ActionType.QueryData);
+        body.queryLotId = queryLotId;
+        body.tableRrn = tableRrn;
+        return body;
     }
 
 }   

--- a/src/components/Table/gc/GCIncomingMaterialImportTable.jsx
+++ b/src/components/Table/gc/GCIncomingMaterialImportTable.jsx
@@ -15,6 +15,7 @@ const TableName = {
 
 const ImportType = {
     GCCOBFinishProduct: "GCCOBFinishProduct",//COB（-4成品）
+    GCCOBRawMaterialProduct: "GCCOBRawMaterialProduct",//COM原料导入
     GCSOCFinishProduct: "GCSOCFinishProduct",//SOC（-4成品）
     GCWLAUnmeasured: "GCWLAUnmeasured",//WLA未测（-2.5）
     GCFabSensor2Unmeasured: "GCFabSensor2Unmeasured",//FAB sensor(-2未测)
@@ -40,10 +41,11 @@ const ImportType = {
     
     GCFinishProductImport: "GCFinishProductImport",//成品导入模板
     GCSOCWaferUnmeasured: "GCSOCWaferUnmeasured",//SOC(-2.5,-2.55未测/-2.6已测)
+    GCMaskFinishProduct: "GCMaskFinishProduct",//Mask成品导入
 }
 
-const ComType = [ImportType.GCCOBFinishProduct, ImportType.GCSOCFinishProduct];
-const wltType = [ImportType.GCWLAUnmeasured];
+const ComType = [ImportType.GCCOBFinishProduct, ImportType.GCSOCFinishProduct, ImportType.GCCOBRawMaterialProduct];
+const wltType = [ImportType.GCWLAUnmeasured, ImportType.GCMaskFinishProduct];
 const CpType = [ImportType.GCFabSensor2Unmeasured, ImportType.GCLCDCPUnmeasured25, ImportType.GCFabLCD1UnmeasuredPTC,
                 ImportType.GCFabLCD1UnmeasuredSilterra, ImportType.GCFabSensor1Unmeasured,ImportType.GCLCDCPMeasured26,
                 ImportType.GCSensorPackageReturn, ImportType.GCSOCWaferUnmeasured, ImportType.GCSensorCPMeasuredHuaLing,
@@ -53,7 +55,7 @@ const RMAType = [ImportType.GCRMAGoodProductImport, ImportType.GCRMACustomerRetu
 
 const resetLocationType = [ImportType.GCWLAUnmeasured, ImportType.GCRMAGoodProductImport, ImportType.GCRMACustomerReturnFinishProduct, 
                            ImportType.GCRMAPureFinishProduct, ImportType.GCCOBFinishProduct, ImportType.GCLCDCOGFinishProductEcretive,
-                           ImportType.GCSOCFinishProduct];
+                           ImportType.GCSOCFinishProduct, ImportType.GCCOBRawMaterialProduct, ImportType.GCMaskFinishProduct];
 
 export default class GCIncomingMaterialImportTable extends EntityListTable {
 
@@ -166,8 +168,8 @@ export default class GCIncomingMaterialImportTable extends EntityListTable {
             Notification.showInfo(I18NUtils.getClientMessage(i18NCode.ChooseImportTypePlease));
             return;
         }
-        if(importType == "COB（-4成品）"){
-            importType = "GCCOBFinishProduct";
+        if(importType == "COM原料导入"){
+            importType = "GCCOBRawMaterialProduct";
         }
         if(tableData.length > 0){
             Notification.showNotice(I18NUtils.getClientMessage(i18NCode.DataNotImportedPleaseCleanAllBeforeSelectNewFile));
@@ -220,10 +222,14 @@ export default class GCIncomingMaterialImportTable extends EntityListTable {
             warehouseId = 8142;
         } else if(warehouseId == "HK_STOCK" || warehouseId == "香港仓库"){
             warehouseId = 8150;
+        } else if(warehouseId == "BS_STOCK" || warehouseId == "保税仓库") {
+            warehouseId = 8151;
         }
 
         let location = data[0].reserved6;
-        if((location == "ZSH" && warehouseId == "8142") || (location == "SH" && warehouseId == "8143")){
+        if((location == "ZSH" && (warehouseId == "8142" || warehouseId == "8151")) 
+            || (location == "SH" && (warehouseId == "8143" || warehouseId == "8151")) 
+            || (location == "BS" && (warehouseId == "8142" || warehouseId == "8143"))){
             Modal.confirm({
                 title: '操作提示',
                 content: I18NUtils.getClientMessage(i18NCode.TheLocationAndWarehouseIsNotSame),
@@ -248,8 +254,8 @@ export default class GCIncomingMaterialImportTable extends EntityListTable {
         let checkFourCodeFlag = this.state.value;
         let importType = this.props.propsFrom.props.form.getFieldValue(queryFields[0].name);
 
-        if(importType == "COB（-4成品）"){
-            importType = "GCCOBFinishProduct";
+        if(importType == "COM原料导入"){
+            importType = "GCCOBRawMaterialProduct";
         }
 
         if(warehouseId == 8142){
@@ -262,7 +268,7 @@ export default class GCIncomingMaterialImportTable extends EntityListTable {
                 materialLot.reserved13 = warehouseId;
                 materialLot.reserved14 = "ZHJ AZ6000";
             });
-        } else if(warehouseId == 8150){
+        } else if(warehouseId == 8150 || warehouseId == 8151){
             data.forEach(materialLot =>{
                 materialLot.reserved13 = warehouseId;
             });

--- a/src/components/Table/gc/MaterialLotQueryTable.jsx
+++ b/src/components/Table/gc/MaterialLotQueryTable.jsx
@@ -1,0 +1,39 @@
+import EntityScanViewTable from '../EntityScanViewTable';
+import I18NUtils from '../../../api/utils/I18NUtils';
+import { i18NCode } from '../../../api/const/i18n';
+import { Tag } from 'antd';
+
+export default class MaterialLotQueryTable extends EntityScanViewTable {
+
+    static displayName = 'MaterialLotQueryTable';
+
+    constructor(props) {
+        super(props);
+        this.state = {...this.state, ...{formTable: {fields: []}}};
+    }
+
+
+    createTagGroup = () => {
+        let buttons = [];
+        buttons.push(this.createNumberStatistic());
+        return buttons;
+    }
+
+    createNumberStatistic = () => {
+        let materialLots = this.state.data;
+        let count = 0;
+        if(materialLots && materialLots.length > 0){
+            materialLots.forEach(data => {
+                if(!data.errorFlag){
+                    count = count +1;
+                }
+            });
+        }
+        return <Tag color="#2db7f5">{I18NUtils.getClientMessage(i18NCode.TotalStrokeCount)}：{count}</Tag>
+    }
+
+    buildOperationColumn = () => {
+        
+    }
+
+}

--- a/src/pages/Properties/components/gc/wafer-issue/GCMobileMaterialLotQueryProperties.jsx
+++ b/src/pages/Properties/components/gc/wafer-issue/GCMobileMaterialLotQueryProperties.jsx
@@ -1,0 +1,81 @@
+import { Notification } from "../../../../../components/notice/Notice";
+import I18NUtils from "../../../../../api/utils/I18NUtils";
+import { i18NCode } from "../../../../../api/const/i18n";
+import MobileProperties from "../../mobile/MobileProperties";
+import MaterialLotQueryTable from "../../../../../components/Table/gc/MaterialLotQueryTable";
+import MaterialLotManagerRequest from "../../../../../api/gc/material-lot-manager/MaterialLotManagerRequest";
+
+export default class GCMobileMaterialLotQueryProperties extends MobileProperties{
+
+    static displayName = 'GCMobileMaterialLotQueryProperties';
+    
+    constructor(props) {
+        super(props);
+        this.state = {...this.state, rowKey: "objectRrn"};
+    }
+
+    queryData = () => {
+      const self = this;
+      let {rowKey,tableData} = this.state;
+      let queryFields = this.form.state.queryFields;
+      let queryLotId = this.form.props.form.getFieldValue(queryFields[0].name);
+      if(queryLotId == "" || queryLotId == null || queryLotId == undefined){
+        Notification.showNotice(I18NUtils.getClientMessage(i18NCode.SearchFieldCannotEmpty));
+        self.setState({ 
+          tableData: tableData,
+          loading: false,
+        });
+        return;
+      }
+      let requestObject = {
+        tableRrn: this.state.tableRrn,
+        queryLotId: queryLotId,
+        success: function(responseBody) {
+          let queryDatas = responseBody.materialLotList;
+          if (queryDatas && queryDatas.length > 0) {
+            queryDatas.forEach(data => {
+              if (tableData.filter(d => d[rowKey] === data[rowKey]).length === 0) {
+                tableData.unshift(data);
+              }
+            });
+            self.setState({ 
+              tableData: tableData,
+              loading: false
+            });
+            self.form.resetFormFileds();
+          } else {
+            self.showDataNotFound();
+          }
+        
+          self.setState({ 
+            tableData: tableData,
+            loading: false
+          });
+          self.form.resetFormFileds();
+        }
+      }
+      MaterialLotManagerRequest.sendGetDataByLotIdOrMLotAndTableRrnRequest(requestObject);
+  }
+
+  showDataNotFound = () => {
+    let queryFields = this.form.state.queryFields;
+    let data = this.form.props.form.getFieldValue(queryFields[0].name);
+    this.setState({ 
+      loading: false
+    });
+    this.allFieldBlur();
+    Notification.showInfo(I18NUtils.getClientMessage(i18NCode.DataNotFound) + (data || ""));
+  }
+    
+  buildTable = () => {
+    return <MaterialLotQueryTable pagination={false} 
+                                rowKey={this.state.rowKey} 
+                                selectedRowKeys={this.state.selectedRowKeys} 
+                                selectedRows={this.state.selectedRows} 
+                                table={this.state.table} 
+                                data={this.state.tableData} 
+                                loading={this.state.loading} 
+                                resetData={this.resetData.bind(this)}/>
+  }
+
+}

--- a/src/routerConfig.js
+++ b/src/routerConfig.js
@@ -149,6 +149,7 @@ import GCMobileMLotIssueByOrderProperties from './pages/Properties/components/gc
 import GcMobileOldRecordExpressNumberProperties from './pages/Properties/components/gc/wafer-issue/GcMobileOldRecordExpressNumberProperties';
 import GcWaferUnpackMLotProperties from './pages/Properties/components/GcWaferUnpackMLotProperties';
 import GCCobRetestLabelAndMakeUpProperties from './pages/Properties/components/GCCobRetestLabelAndMakeUpProperties';
+import GCMobileMaterialLotQueryProperties from './pages/Properties/components/gc/wafer-issue/GCMobileMaterialLotQueryProperties';
 
 /**
  * 构建url ?表示可选参数
@@ -1044,7 +1045,7 @@ const routerConfig = [
   {
     path: buildPath('Mobile/MaterialLotQuery'),
     layout: BlankLayout,
-    component: MobileProperties,
+    component: GCMobileMaterialLotQueryProperties,
   },
   {
     path: buildPath('Mobile/MaterialLotReceive'),


### PR DESCRIPTION
1. 修改“来料导入”中的“COB(-4成品)”为“COM原料导入”；
2. 添加“COB成品”导入在“来料导入”中；
3. 添加“SOC成品”导入在“来料导入”中；
4. 添加“MASK成品”导入在“来料导入”中；
5.优化手持端”物料查询“，可查询COM，晶圆，原材料的库存信息。