### PR TITLE
 #390 RW出货标注修改

### DIFF
--- a/src/api/const/i18n.js
+++ b/src/api/const/i18n.js
@@ -78,6 +78,7 @@ const i18NCode = {
     BtnSaleShip: "SaleShip",
     BtnAddShipOrder: "AddShipOrder",
     BtnCancelShipOrder: "CancelShipOrder",
+    BtnPreview: "Preview",
     BtnSpareMaterial: "SpareMaterial",
     BtnSpareMaterialConfirm: "SpareMaterialConfirm",
     BtnScrapShip: "ScrapShip",
@@ -1248,6 +1249,11 @@ const i18Messages = {
         Chinese: "取消发货单",
         English: "CancelSaleShip",
         Res: ""     
+    },
+    Preview: {
+        Chinese: "预览",
+        English: "Preview",
+        Res: ""   
     },
     ShipOrderId: {
         Chinese: "发货单号",

--- a/src/api/gc/rw-manager/RwMLotManagerRequest.js
+++ b/src/api/gc/rw-manager/RwMLotManagerRequest.js
@@ -89,6 +89,30 @@ export default class RwMLotManagerRequest {
         MessageUtils.sendRequest(requestObject);
     }
 
+    static sendCancelShipOrderIdRequest = (object) => {
+        let {materialLotList} = object;
+        let requestBody = RwMLotManagerRequestBody.buildMLotCancelShipOrderId(materialLotList);
+        let requestHeader = new RwMLotManagerRequestHeader();
+        let request = new Request(requestHeader, requestBody, UrlConstant.GCRwMaterialLotManageUrl);
+        let requestObject = {
+            request: request,
+            success: object.success
+        }
+        MessageUtils.sendRequest(requestObject);
+    }
+
+    static sendPreViewMLotRequest = (object) => {
+        let {materialLotList} = object;
+        let requestBody = RwMLotManagerRequestBody.buildMLotPreViewMLot(materialLotList);
+        let requestHeader = new RwMLotManagerRequestHeader();
+        let request = new Request(requestHeader, requestBody, UrlConstant.GCRwMaterialLotManageUrl);
+        let requestObject = {
+            request: request,
+            success: object.success
+        }
+        MessageUtils.sendRequest(requestObject);
+    }
+
     static sendGetMaterialLotByRrnRequest = (object) => {
         let {tableRrn, queryLotId} = object;
         let requestBody = RwMLotManagerRequestBody.buildRwStockOutMLotByTableRrnAndLotId(tableRrn, queryLotId);

--- a/src/api/gc/rw-manager/RwMLotManagerRequestBody.js
+++ b/src/api/gc/rw-manager/RwMLotManagerRequestBody.js
@@ -7,6 +7,8 @@ const ActionType = {
     StockOutTag: "StockOutTag",
     UnStockOutTag: "UnStockOutTag",
     AddShipOrderId: "AddShipOrderId",
+    CancelShipOrderId: "CancelShipOrderId",
+    PreView: "PreView",
     QueryMLot: "QueryMLot",
     ValidateMLot: "ValidateMLot",
     StockOut: "StockOut",
@@ -100,6 +102,16 @@ export default class RwMLotManagerRequestBody {
     static buildMLotAddShipOrderId(materialLotList, shipOrderId) {
         let body = new RwMLotManagerRequestBody(ActionType.AddShipOrderId, materialLotList);
         body.shipOrderId = shipOrderId;
+        return body;
+    }
+
+    static buildMLotCancelShipOrderId(materialLotList) {
+        let body = new RwMLotManagerRequestBody(ActionType.CancelShipOrderId, materialLotList);
+        return body;
+    }
+
+    static buildMLotPreViewMLot(materialLotList) {
+        let body = new RwMLotManagerRequestBody(ActionType.PreView, materialLotList);
         return body;
     }
 

--- a/src/components/Table/gc/GCRwStockOutTaggingUpdateTable.jsx
+++ b/src/components/Table/gc/GCRwStockOutTaggingUpdateTable.jsx
@@ -1,4 +1,4 @@
-import { Button, Col, Input, Row, Tag } from 'antd';
+import { Button, Col, Input, Row, Tag , Upload} from 'antd';
 import I18NUtils from '../../../api/utils/I18NUtils';
 import { i18NCode } from '../../../api/const/i18n';
 import RwMLotManagerRequest from "../../../api/gc/rw-manager/RwMLotManagerRequest";
@@ -6,12 +6,18 @@ import EntityListCheckTable from '../EntityListCheckTable';
 import FormItem from 'antd/lib/form/FormItem';
 import EventUtils from '../../../api/utils/EventUtils';
 import { Notification } from '../../notice/Notice';
+import MaterialLotUpdateRequest from '../../../api/gc/materialLot-update-manager/MaterialLotUpdateRequest';
+import RWStockOutTagUpdateMLotForm from './RWStockOutTagUpdateMLotForm';
 
 export default class GCRwStockOutTaggingUpdateTable extends EntityListCheckTable {
 
     createButtonGroup = () => {
         let buttons = [];
+        buttons.push(this.createExportDataAndTemplateButton());
+        buttons.push(this.createImportSearchButton());
         buttons.push(this.createAddShipOrderButton());
+        buttons.push(this.createCancelShipOrderButton());
+        buttons.push(this.createPreviewButton());
         buttons.push(this.createCancelStockOutButton());
         return buttons;
     }
@@ -97,6 +103,100 @@ export default class GCRwStockOutTaggingUpdateTable extends EntityListCheckTable
         RwMLotManagerRequest.sendAddShipOrderIdRequest(requestObject);
     }
 
+    Preview = () => {
+        let self = this;
+        let materialLots = this.getSelectedRows();
+        if (materialLots.length === 0 ) {
+            return;
+        }
+
+        // self.setState({
+        //     loading: true
+        // });
+        // EventUtils.getEventEmitter().on(EventUtils.getEventNames().ButtonLoaded, () => self.setState({loading: false}));
+        
+        let requestObject = {
+            materialLotList : materialLots,
+            success: function(responseBody) {
+                let materialLotInfo = responseBody.materialLotList;
+                self.setState({
+                    formVisible : true,
+                    materialLotInfo: materialLotInfo,
+                }); 
+            }
+        }
+        RwMLotManagerRequest.sendPreViewMLotRequest(requestObject);
+    }
+
+    createForm = () => {
+        return  <RWStockOutTagUpdateMLotForm visible={this.state.formVisible} 
+                                     materialLotInfo={this.state.materialLotInfo}
+                                     width={1440}
+                                     onOk={this.handleCancel} 
+                                     onCancel={this.handleCancel}/>
+    }
+
+    handleCancel = (e) => {
+        this.setState({
+            formVisible: false,
+        })
+    }
+
+    CancelShipOrder = () => {
+        let self = this;
+        let materialLotList = this.getSelectedRows();
+        if (materialLotList.length === 0 ) {
+            return;
+        }
+
+        self.setState({
+            loading: true
+        });
+        EventUtils.getEventEmitter().on(EventUtils.getEventNames().ButtonLoaded, () => self.setState({loading: false}));
+        
+        let requestObject = {
+            materialLotList : materialLotList,
+            success: function(responseBody) {
+                self.setState({
+                    selectedRowKeys: [],
+                    selectedRows: [],
+                });
+                if (self.props.resetData) {
+                    self.props.resetData();
+                    self.props.onSearch();
+                }
+            }
+        }
+        RwMLotManagerRequest.sendCancelShipOrderIdRequest(requestObject);
+    }
+
+    importSearch = (option) => {
+        const self = this;
+        const {table} = this.state;
+        let tableData = this.state.data;
+        if(tableData.length > 0){
+            Notification.showNotice(I18NUtils.getClientMessage(i18NCode.TableDataMustBeEmpty));
+            return;
+        }
+
+        self.setState({
+            loading: true
+        });
+        EventUtils.getEventEmitter().on(EventUtils.getEventNames().ButtonLoaded, () => this.setState({loading: false}));
+        
+        let object = {
+            tableRrn: table.objectRrn,
+            success: function(responseBody) {
+                let materialLotList = responseBody.materialLotList;
+                self.setState({
+                    data: materialLotList,
+                    loading: false
+                });           
+            }
+        }
+        MaterialLotUpdateRequest.sendImportSearchRequest(object, option.file);
+    }
+
     createStatistic = () => {
         return <Tag color="#2db7f5">{I18NUtils.getClientMessage(i18NCode.BoxQty)}：{this.state.data.length}</Tag>
     }
@@ -132,6 +232,25 @@ export default class GCRwStockOutTaggingUpdateTable extends EntityListCheckTable
     createAddShipOrderButton = () => {
         return <Button key="addShipOrder" type="primary" style={styles.tableButton} icon="inbox" loading={this.state.loading} onClick={this.AddShipOrder}>
                         {I18NUtils.getClientMessage(i18NCode.BtnAddShipOrder)}
+                    </Button>
+    }
+
+    createImportSearchButton = () => {
+        return (<Upload key="importSearch" accept="application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" 
+                    customRequest={(option) => this.importSearch(option)} showUploadList={false} >
+                    <Button type="primary" style={styles.tableButton} loading={this.state.loading} icon="file-add">{I18NUtils.getClientMessage(i18NCode.BtnImportSearch)}</Button>
+                </Upload>);
+    }
+
+    createCancelShipOrderButton = () => {
+        return <Button key="cancelShipOrder" type="primary" style={styles.tableButton} icon="inbox" loading={this.state.loading} onClick={this.CancelShipOrder}>
+                        {I18NUtils.getClientMessage(i18NCode.BtnCancelShipOrder)}
+                    </Button>
+    }
+
+    createPreviewButton = () => {
+        return <Button key="preview" type="primary" style={styles.tableButton} icon="inbox" loading={this.state.loading} onClick={this.Preview}>
+                        {I18NUtils.getClientMessage(i18NCode.BtnPreview)}
                     </Button>
     }
 

--- a/src/components/Table/gc/GcRwStockOutTagUpdateMLotShowTable.jsx
+++ b/src/components/Table/gc/GcRwStockOutTagUpdateMLotShowTable.jsx
@@ -1,0 +1,104 @@
+import {Tag} from 'antd';
+import TableManagerRequest from '../../../api/table-manager/TableManagerRequest';
+import EntityListTable from '../EntityListTable';
+import I18NUtils from '../../../api/utils/I18NUtils';
+import { i18NCode } from '../../../api/const/i18n';
+import "../../Form/QueryForm.scss";
+
+const TableName = {
+    GCRwStockOutTagUpdateMLotShow: "GCRwStockOutTagUpdateMLotShow",
+}
+
+/**
+ * COB出货标注修改数量总计展示表格
+ */
+export default class GcRwStockOutTagUpdateMLotShowTable extends EntityListTable {
+
+    static displayName = 'GcRwStockOutTagUpdateMLotShowTable';
+    
+    componentWillReceiveProps = (props) => {
+        const {visible, materialLotInfo} = props;
+        let self = this;
+        if (visible) {
+            self.setState({
+                data: materialLotInfo
+            })
+        } else {
+            self.setState({
+                data: [],
+                selectedRows: [],
+                selectedRowKeys: []
+            })
+        }
+    }   
+
+    getMaterialLotList = () => {
+        const {visible, materialLotInfo} = this.props;
+        let self = this;
+        if (visible) {
+            self.setState({
+                data: materialLotInfo
+            })
+        }
+    }
+
+    componentDidMount = () => {
+        const self = this;
+        self.getMaterialLotList();
+        let requestObject = {
+            name: TableName.GCRwStockOutTagUpdateMLotShow,
+            success: function(responseBody) {
+                let table = responseBody.table;
+                let columnData = self.buildColumn(table);
+                self.setState({
+                    table: table,
+                    columns: columnData.columns,
+                    scrollX: columnData.scrollX,
+                    loading: false
+                }); 
+            }
+        }
+        TableManagerRequest.sendGetByNameRequest(requestObject);
+    }
+    
+    createButtonGroup = () => {
+        let buttons = [];
+        buttons.push(this.createBoxQty());
+        buttons.push(this.createWaferNumber());
+        buttons.push(this.createTotalNumber());
+        return buttons;
+    }
+
+    createBoxQty = () => {
+        return <Tag color="#2db7f5">{I18NUtils.getClientMessage(i18NCode.BoxQty)}：{this.state.data.length}</Tag>
+    }
+
+    createWaferNumber = () => {
+        let materialLots = this.state.data;
+        let qty = 0;
+        if(materialLots && materialLots.length > 0){
+            materialLots.forEach(data => {
+                if (data.currentSubQty != undefined) {
+                    qty = qty + parseInt(data.currentSubQty);
+                }
+            });
+        }
+        return <Tag color="#2db7f5">{I18NUtils.getClientMessage(i18NCode.PieceQty)}：{qty}</Tag>
+    }
+
+    createTotalNumber = () => {
+        let materialLots = this.state.data;
+        let count = 0;
+        if(materialLots && materialLots.length > 0){
+            materialLots.forEach(data => {
+                count = count + data.currentQty;
+            });
+        }
+        return <Tag color="#2db7f5">{I18NUtils.getClientMessage(i18NCode.TotalQty)}:{count}</Tag>
+    }
+
+    buildOperationColumn = () => {
+        
+    }
+
+}

--- a/src/components/Table/gc/RWStockOutTagUpdateMLotForm.jsx
+++ b/src/components/Table/gc/RWStockOutTagUpdateMLotForm.jsx
@@ -1,0 +1,32 @@
+import  React from 'react';
+import { DefaultRowKey } from '../../../api/const/ConstDefine';
+import EntityForm from '../../Form/EntityForm';
+import GcRwStockOutTagUpdateMLotShowTable from './GcRwStockOutTagUpdateMLotShowTable';
+
+export default class RWStockOutTagUpdateMLotForm extends EntityForm {
+
+    static displayName = 'RWStockOutTagUpdateMLotForm';
+
+    constructor(props) {
+        super(props);
+    }
+    
+    componentWillReceiveProps = (props) => {
+    }
+
+    handleOk= () => {
+        let self = this;
+        self.props.onOk();
+    }
+
+    buildForm = () => {
+        return (<GcRwStockOutTagUpdateMLotShowTable ref={(materialLotTable) => { this.materialLotTable = materialLotTable }} 
+                                        rowKey={DefaultRowKey} 
+                                        materialLotInfo={this.props.materialLotInfo}
+                                        visible={this.props.visible} />);
+    }
+}
+
+RWStockOutTagUpdateMLotForm.propTypes={
+}
+

--- a/src/pages/Properties/components/GCRwStockOutTagProperties.jsx
+++ b/src/pages/Properties/components/GCRwStockOutTagProperties.jsx
@@ -40,56 +40,68 @@ export default class GCRwStockOutTagProperties extends EntityScanProperties{
     /**
      * 重新赋值下拉框
      */
-    resetComBoxData = (data) =>{
-        let gradeField = this.form.state.queryFields[6]
-        let gradeNode = gradeField.node;
-        
-        let secondLevelField = this.form.state.queryFields[7];
-        let secondLevelNode = secondLevelField.node;
+     resetComBoxData = (data) =>{
+      let queryFields = this.form.state.queryFields;
+      if (queryFields && Array.isArray(queryFields)) {
+       let gradeIndex = -1;
+       let subCodeIndex = -1;
+       queryFields.map((queryField, index) => {
+           if (queryField.name == "grade") {
+               gradeIndex = index;
+           } else if(queryField.name == "reserved1"){
+             subCodeIndex = index;
+           }
+       });
 
-        if(!data || data.length == 0){
-            gradeNode.queryData();
-            secondLevelNode.queryData();
-            return;
-        }
+       let gradeField = this.form.state.queryFields[gradeIndex]
+       let gradeNode = gradeField.node;
+       
+       let secondLevelField = this.form.state.queryFields[subCodeIndex];
+       let secondLevelNode = secondLevelField.node;
 
-        let gradeList = [];
-        let gradeRefData = [];
+       if(!data || data.length == 0){
+           gradeNode.queryData();
+           secondLevelNode.queryData();
+           return;
+       }
 
-        let secondLevelList = [];
-        let secondLevelRefData = [];
+       let gradeList = [];
+       let gradeRefData = [];
 
-        // 获取相关字段的值
-        data.forEach((d,index) => {
-            if(gradeList.indexOf(d[gradeField.name]) == -1){
-                gradeList.push(d[gradeField.name]);
-            }
+       let secondLevelList = [];
+       let secondLevelRefData = [];
 
-            if(secondLevelList.indexOf(d[secondLevelField.name]) == -1){
-              secondLevelList.push(d[secondLevelField.name]);
-            }
-        });
+       // 获取相关字段的值
+       data.forEach((d,index) => {
+           if(gradeList.indexOf(d[gradeField.name]) == -1){
+               gradeList.push(d[gradeField.name]);
+           }
 
-        // 组装数据
-        gradeList.forEach((d,index) => {
-            let gradeObject = {};
-            // whereClause 得到的值是 key,显示的值是 value
-            gradeObject.key = d;
-            gradeObject.value = d;
-            gradeRefData.push(gradeObject);
-        })
+           if(secondLevelList.indexOf(d[secondLevelField.name]) == -1){
+             secondLevelList.push(d[secondLevelField.name]);
+           }
+       });
 
-        secondLevelList.forEach(d => {
-            let secondLevelObject = {};
-            secondLevelObject.key = d;
-            secondLevelObject.value = d;
-            secondLevelRefData.push(secondLevelObject);
-        })
+       // 组装数据
+       gradeList.forEach((d,index) => {
+           let gradeObject = {};
+           // whereClause 得到的值是 key,显示的值是 value
+           gradeObject.key = d;
+           gradeObject.value = d;
+           gradeRefData.push(gradeObject);
+       })
 
-        gradeNode.setState({data:gradeRefData});
-        secondLevelNode.setState({data:secondLevelRefData});        
-     
-    }
+       secondLevelList.forEach(d => {
+           let secondLevelObject = {};
+           secondLevelObject.key = d;
+           secondLevelObject.value = d;
+           secondLevelRefData.push(secondLevelObject);
+       })
+
+       gradeNode.setState({data:gradeRefData});
+       secondLevelNode.setState({data:secondLevelRefData});   
+     } 
+ }
 
     buildTable = () => {
         return <GCRwStockOutTaggingTable pagination={false} 

--- a/src/pages/Properties/components/GCRwStockOutTaggingUpdateProperties.jsx
+++ b/src/pages/Properties/components/GCRwStockOutTaggingUpdateProperties.jsx
@@ -23,6 +23,7 @@ export default class GCRwStockOutTaggingUpdateProperties extends EntityScanPrope
         tableRrn: this.state.tableRrn,
         whereClause: whereClause,
         success: function(responseBody) {
+          self.resetComBoxData(responseBody.dataList);
           self.setState({
             tableData: responseBody.dataList,
             loading: false
@@ -31,6 +32,73 @@ export default class GCRwStockOutTaggingUpdateProperties extends EntityScanPrope
       }
       TableManagerRequest.sendGetDataByRrnRequest(requestObject);
     }
+
+    
+    /**
+     * 重新赋值下拉框
+     */
+     resetComBoxData = (data) =>{
+       let queryFields = this.form.state.queryFields;
+       if (queryFields && Array.isArray(queryFields)) {
+        let gradeIndex = -1;
+        let subCodeIndex = -1;
+        queryFields.map((queryField, index) => {
+            if (queryField.name == "grade") {
+                gradeIndex = index;
+            } else if(queryField.name == "reserved1"){
+              subCodeIndex = index;
+            }
+        });
+
+        let gradeField = this.form.state.queryFields[gradeIndex]
+        let gradeNode = gradeField.node;
+        
+        let secondLevelField = this.form.state.queryFields[subCodeIndex];
+        let secondLevelNode = secondLevelField.node;
+
+        if(!data || data.length == 0){
+            gradeNode.queryData();
+            secondLevelNode.queryData();
+            return;
+        }
+
+        let gradeList = [];
+        let gradeRefData = [];
+
+        let secondLevelList = [];
+        let secondLevelRefData = [];
+
+        // 获取相关字段的值
+        data.forEach((d,index) => {
+            if(gradeList.indexOf(d[gradeField.name]) == -1){
+                gradeList.push(d[gradeField.name]);
+            }
+
+            if(secondLevelList.indexOf(d[secondLevelField.name]) == -1){
+              secondLevelList.push(d[secondLevelField.name]);
+            }
+        });
+
+        // 组装数据
+        gradeList.forEach((d,index) => {
+            let gradeObject = {};
+            // whereClause 得到的值是 key,显示的值是 value
+            gradeObject.key = d;
+            gradeObject.value = d;
+            gradeRefData.push(gradeObject);
+        })
+
+        secondLevelList.forEach(d => {
+            let secondLevelObject = {};
+            secondLevelObject.key = d;
+            secondLevelObject.value = d;
+            secondLevelRefData.push(secondLevelObject);
+        })
+
+        gradeNode.setState({data:gradeRefData});
+        secondLevelNode.setState({data:secondLevelRefData});   
+      } 
+  }
 
     buildTable = () => {
         return <GCRwStockOutTaggingUpdateTable pagination={false} 


### PR DESCRIPTION
1、查询条件等级、二级代码筛选列标中物料批次中包含的等级何二级代码；
2、入库备注支持模糊查询；
3、添加导出按钮
4、新增栏位记录标注人、标注时间（年月日）
6、新增“取消发货单”按钮，清除发货单信息；
7、新增数量统计按钮，按照（标注信息、供应商、产品类型、等级、二级代码、入库备注）分组，显示总数量。